### PR TITLE
adjust bpid format for HW Pacific storage

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -1452,8 +1452,15 @@ public class RouterRpcClient {
    */
   private String getNameserviceForBlockPoolId(final String bpId)
       throws IOException {
+      String fixedBpId = bpId;
+      if (bpId.startsWith("BP-huawei")) {
+        int index = bpId.indexOf('|');
+        if (index != -1) {
+          fixedBpId = bpId.substring(0, index);
+        }
+      }
     List<? extends FederationNamenodeContext> namenodes =
-        getNamenodesForBlockPoolId(bpId);
+        getNamenodesForBlockPoolId(fixedBpId);
     FederationNamenodeContext namenode = namenodes.get(0);
     return namenode.getNameserviceId();
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

